### PR TITLE
Allow console to be exposed through a route

### DIFF
--- a/bin/console_server.js
+++ b/bin/console_server.js
@@ -25,13 +25,15 @@ var router_stats = require('../lib/router_stats.js');
 var broker_stats = require('../lib/broker_stats.js');
 var UserCtrl = require('../lib/user_ctrl.js');
 var Registry = require('../lib/registry.js');
+var http = require('http');
 
 var app = express();
-app.set('port', 8080);
-app.use(express.static(path.join(__dirname, '../www/')))
-var http_server = app.listen(app.get('port'));
+app.use('/', express.static(path.join(__dirname, '../www/')))
 
-var ws_server = new WebSocketServer({'port':56720});
+var server = http.createServer(app);
+server.listen(8080);
+
+var ws_server = new WebSocketServer({server: server, 'path': '/websocket'});
 var amqp_container = rhea.create_container({autoaccept:false});
 ws_server.on('connection', function (ws) {
     console.log('Accepted incoming websocket connection');

--- a/lib/address_ctrl.js
+++ b/lib/address_ctrl.js
@@ -18,7 +18,16 @@
 var http = require('http');
 var Promise = require('bluebird');
 
-var ctrlr = require('./admin_service.js').hostport('ADDRESS_CONTROLLER', {host:'localhost', port:8080});
+function hostport(defaults) {
+    var result = defaults;
+    if (process.env.ADDRESS_CONTROLLER_SERVICE_HOST) {
+        result.host = process.env.ADDRESS_CONTROLLER_SERVICE_HOST;
+        result.port = process.env.ADDRESS_CONTROLLER_SERVICE_PORT;
+    }
+    return result;
+}
+
+var ctrlr = hostport({host:'localhost', port:8080});
 
 function request(path, method, headers, body, handler) {
     return new Promise(function (resolve, reject) {

--- a/www/address_service.js
+++ b/www/address_service.js
@@ -105,7 +105,7 @@ function AddressService() {
     this.connections = [];
     this.users = [];
     var ws = rhea.websocket_connect(WebSocket);
-    this.connection = rhea.connect({"connection_details":ws("ws://" + location.hostname + ":56720", ["binary", "AMQPWSB10"]), "reconnect":true});
+    this.connection = rhea.connect({"connection_details":ws("ws://" + location.hostname + ":" + location.port + "/websocket", ["binary", "AMQPWSB10"]), "reconnect":true});
     this.connection.on('message', this.on_message.bind(this));
     this.sender = this.connection.open_sender();
     this.connection.open_receiver();


### PR DESCRIPTION
This changes so that http and websocket listens on the same port. This is a result of me trying to expose the router console through a route. The issue with using separate ports, is that we have to create 2 routes. With 2 routes, you need 2 different hostnames (because they will eventually use the same ha-proxy port, so there is no way to distinguish them otherwise).

Instead, this PR changes the console to share the http port for both the console and the websocket listener, but assigns different paths to them. 

There is also a fix to use the correct environment for communicating with the address controller.