### PR TITLE
Adding dashboard page

### DIFF
--- a/www/address_service.js
+++ b/www/address_service.js
@@ -120,7 +120,7 @@ AddressService.prototype.update_depth_series = function () {
             changed = true;
         }
     }
-    if (changed && this.callback) this.callback();
+    if (changed && this.callback) this.callback('update_depth_series');
 };
 
 AddressService.prototype.reset_periodic_deltas = function () {
@@ -130,7 +130,7 @@ AddressService.prototype.reset_periodic_deltas = function () {
             changed = true;
         }
     }
-    if (changed && this.callback) this.callback();
+    if (changed && this.callback) this.callback('reset_periodic_deltas');
 };
 
 AddressService.prototype.update = function (a) {
@@ -216,7 +216,7 @@ AddressService.prototype.update_user = function (c) {
 AddressService.prototype.on_message = function (context) {
     if (context.message.subject === 'address') {
         this.update(context.message.body);
-        if (this.callback) this.callback();
+        if (this.callback) this.callback('address');
     } else if (context.message.subject === 'address_deleted') {
         var changed = false;
         for (var i = 0; i < this.addresses.length;) {
@@ -227,13 +227,13 @@ AddressService.prototype.on_message = function (context) {
                 i++;
             }
         }
-        if (changed && this.callback) this.callback();
+        if (changed && this.callback) this.callback('address:deleted');
     } else if (context.message.subject === 'flavors') {
         this.flavors = context.message.body;
-        if (this.callback) this.callback();
+        if (this.callback) this.callback('flavors');
     } else if (context.message.subject === 'connection') {
         this.update_connection(context.message.body);
-        if (this.callback) this.callback();
+        if (this.callback) this.callback('connection');
     } else if (context.message.subject === 'connection_deleted') {
         var changed = false;
         for (var i = 0; i < this.connections.length;) {
@@ -244,11 +244,11 @@ AddressService.prototype.on_message = function (context) {
                 i++;
             }
         }
-        if (changed && this.callback) this.callback();
+        if (changed && this.callback) this.callback("connection:deleted");
     } else if (context.message.subject === 'user') {
         console.log('got user: ' + JSON.stringify(context.message.body));
         this.update_user(context.message.body);
-        if (this.callback) this.callback();
+        if (this.callback) this.callback("user");
     } else if (context.message.subject === 'user_deleted') {
         var changed = false;
         for (var i = 0; i < this.users.length;) {
@@ -259,7 +259,7 @@ AddressService.prototype.on_message = function (context) {
                 i++;
             }
         }
-        if (changed && this.callback) this.callback();
+        if (changed && this.callback) this.callback("user:deleted");
     }
 }
 

--- a/www/css/enmasse.css
+++ b/www/css/enmasse.css
@@ -1,0 +1,3 @@
+#dashboard {
+    margin: 4em 0.5em 0 0.5em;
+}

--- a/www/dashboard.html
+++ b/www/dashboard.html
@@ -1,0 +1,41 @@
+    <div id="dashboard" ng-controller="DashCtrl" class="row example-container">
+        <div class="card-pf card-pf-utilization">
+            <div class="card-pf-heading">
+                <h2 class="card-pf-title" style="height: 17px;">
+                    Breakdown by address
+                </h2>
+            </div>
+            <div class="card-pf-body">
+                <div class="row">
+                    <div ng-repeat="pie in pies track by $index">
+                        <div class="col-xs-12 col-sm-4 col-md-4">
+                            <h3 class="card-pf-subtitle">{{pie.title}}</h3>
+                            <div id="pie-chart-{{pie.name}}" class="pie-chart-pf example-pie-chart-mini"></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="card-pf-heading">
+                <h2 class="card-pf-title" style="height: 17px;">
+                    Totals for all addresses
+                </h2>
+            </div>
+            <div class="card-pf-body">
+                <div class="row">
+                    <div ng-repeat="pie in pies track by $index">
+                        <div class="col-xs-12 col-sm-4 col-md-4">
+                            <h3 class="card-pf-subtitle">{{pie.title}}</h3>
+                            <p class="card-pf-utilization-details">
+                                <span class="card-pf-utilization-card-details-count">{{pie.current_value  | number : fractionSize}}</span>
+                                <span class="card-pf-utilization-card-details-description">
+                               <span class="card-pf-utilization-card-details-line-1">{{pie.detail1}}</span>
+                               <span class="card-pf-utilization-card-details-line-2">{{pie.detail2}}</span>
+                             </span>
+                            </p>
+                            <div class="chart-pf-sparkline c3" id="chart-pf-sparkline-{{pie.name}}"></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>

--- a/www/index.html
+++ b/www/index.html
@@ -9,6 +9,7 @@
 
     <!-- Angular-PatternFly Styles -->
     <link rel="stylesheet" href="bower_components/angular-patternfly/dist/styles/angular-patternfly.min.css" />
+    <link rel="stylesheet" href="css/enmasse.css" />
 
     <script src="bower_components/angular-patternfly/dist/docs/grunt-scripts/jquery.js"></script>
     <script src="bower_components/angular-patternfly/dist/docs/grunt-scripts/bootstrap.js"></script>
@@ -32,6 +33,7 @@
     <script src="bower_components/angular-patternfly/dist/docs/grunt-scripts/angular-drag-and-drop-lists.js"></script>
 
     <script src="script.js"></script>
+    <script src="js/dashboard_ctrl.js"></script>
     <script src="rhea.js"></script>
     <script src="address_service.js"></script>
   </head>

--- a/www/js/dashboard_ctrl.js
+++ b/www/js/dashboard_ctrl.js
@@ -19,7 +19,7 @@ var dashboard_ctrl = function($scope, $timeout, address_service) {
             title: 'Messages',
             name: 'pieMessages',
             detail1: 'Total messages processed',
-            detail2: 'for all addresses',
+            detail2: 'for all active clients',
             datafn: function(item) {
                 return item.messages_out
             },
@@ -117,6 +117,7 @@ var dashboard_ctrl = function($scope, $timeout, address_service) {
             type: 'pie',
             colors: {},
             columns: [],
+            empty: { label: { text: "No Data Available" }},
         };
         var addressvals = Object.keys(this.address_map).map(function(address) {
             return {

--- a/www/js/dashboard_ctrl.js
+++ b/www/js/dashboard_ctrl.js
@@ -1,0 +1,181 @@
+var dashboard_ctrl = function($scope, $timeout, address_service) {
+
+    function PieChart(obj) {
+        this.title = obj.title || ''
+        this.name = obj.name || ''
+        this.detail1 = obj.detail1 || ''
+        this.detail2 = obj.detail2 || ''
+        this.current_value = obj.current_value || 0
+        this.address_map = obj.address_map || {}
+        this.reference = obj.reference || undefined
+        this.datafn = obj.datafn || function() {
+            return null
+        }
+        this.data = obj.data || []
+    }
+
+    $scope.pies = [
+        new PieChart({
+            title: 'Messages',
+            name: 'pieMessages',
+            detail1: 'Total messages processed',
+            detail2: 'for all addresses',
+            datafn: function(item) {
+                return item.messages_out
+            },
+        }),
+        new PieChart({
+            title: 'Senders',
+            name: 'pieSenders',
+            detail1: 'Number of senders',
+            datafn: function(item) {
+                return item.senders
+            },
+        }),
+        new PieChart({
+            title: 'Receivers',
+            name: 'pieReceivers',
+            detail1: 'Number of receivers',
+            datafn: function(item) {
+                return item.receivers
+            },
+        }),
+    ];
+
+    // called by address_service each time an address' data changes
+    var on_update = function (reason) {
+        $timeout(function () {
+          if (!reason) reason = '';
+          if (reason.split(':')[0] !== 'address') {
+              return;
+          }
+          $scope.pies.forEach(function(pie, i) {
+              pie.update()
+          })
+        })
+    };
+
+    // ensure all pie charts use same color for each address
+    var pieColors = [$.pfPaletteColors.red, $.pfPaletteColors.blue, $.pfPaletteColors.orange,
+        $.pfPaletteColors.green, $.pfPaletteColors.red200
+    ]
+    var address_color_map = {}
+    var color4Address = function(a) {
+        if (address_color_map[a])
+            return address_color_map[a]
+        var index = Object.keys(address_color_map).length
+        // always use grey for 'other' pie slice
+        if (index >= pieColors.length)
+            address_color_map[a] = $.pfPaletteColors.black400
+        else
+            address_color_map[a] = pieColors[index]
+        return address_color_map[a]
+    }
+
+    PieChart.prototype.update = function (piedata) {
+        var piedata = 0
+        this.address_map = {}
+        items.forEach(function(item) {
+            var data = this.datafn(item)
+            // accumulate data for line chart
+            piedata += data
+            // catagorize data for pie chart
+            if (data)
+                this.address_map[item.address] = this.address_map[item.address] ? this.address_map[item.address] + data : data;
+        }, this)
+        this.current_value = piedata;
+        // store up to 10 values for line chart
+        this.data.push(this.current_value)
+        while (this.data.length > 10) {
+            this.data.shift()
+        }
+        this.draw_pie()
+        this.draw_lines()
+    }
+
+    PieChart.prototype.draw_lines = function() {
+        var data = {
+            columns: [
+                [this.title]
+            ],
+            type: 'area'
+        };
+        Array.prototype.push.apply(data.columns[0], this.data)
+
+        if (!this.spark_reference) {
+            var sparklineChartConfig = $().c3ChartDefaults().getDefaultSparklineConfig();
+            sparklineChartConfig.bindto = '#chart-pf-sparkline-' + this.name;
+            sparklineChartConfig.data = data
+            this.spark_reference = c3.generate(sparklineChartConfig);
+        } else {
+            this.spark_reference.load(data)
+        }
+    }
+
+    PieChart.prototype.draw_pie = function() {
+        var pieData = {
+            type: 'pie',
+            colors: {},
+            columns: [],
+        };
+        var addressvals = Object.keys(this.address_map).map(function(address) {
+            return {
+                address: address,
+                value: this.address_map[address]
+            }
+        }, this)
+        addressvals.sort(function(a, b) {
+            return b.value - a.value
+        })
+        // if there are 6 or more addresses, collapse those not in top 4 into 'other'
+        if (addressvals.length >= 6) {
+            for (var i = 4, other = 0; i < addressvals.length; ++i) {
+                other += addressvals[i].value
+            }
+            while (addressvals.length > 4)
+                addressvals.pop()
+            addressvals.push({
+                address: 'Other',
+                value: other
+            })
+        }
+        addressvals.forEach(function(av) {
+            pieData.colors[av.address] = color4Address(av.address)
+            pieData.columns.push([av.address, av.value])
+        })
+
+        // only call c3.generate() once. after that call .load()
+        // otherwise c3 will leak memory. https://github.com/c3js/c3/issues/926
+        if (!this.reference) {
+            var c3ChartDefaults = $().c3ChartDefaults();
+            var pieChartSmallConfig = c3ChartDefaults.getDefaultPieConfig();
+            pieChartSmallConfig.bindto = '#pie-chart-' + this.name;
+            pieChartSmallConfig.data = pieData;
+            pieChartSmallConfig.legend = {
+                show: true,
+                position: 'right'
+            };
+            pieChartSmallConfig.size = {
+                width: 260,
+                height: 115
+            };
+            this.reference = c3.generate(pieChartSmallConfig);
+        } else {
+            this.reference.load(pieData)
+        }
+    }
+    $scope.$on('$destroy', function() {
+        $scope.pies.forEach(function(pie) {
+            if (pie.reference) pie.reference.destroy()
+            if (pie.spark_reference) pie.spark_reference.destroy()
+        })
+    })
+
+    var items = address_service.addresses;
+    address_service.on_update(on_update)
+
+    // draw charts without waiting for on_update event from address_service
+    on_update("address")
+}
+
+angular.module('patternfly.toolbars').controller('DashCtrl', ['$scope', '$timeout', 'address_service', dashboard_ctrl])

--- a/www/script.js
+++ b/www/script.js
@@ -753,7 +753,12 @@ angular.module('patternfly.wizard').controller('UserFormController', ['$rootScop
 
 angular.module('myapp', ['patternfly.navigation', 'ui.router', 'patternfly.views', 'patternfly.toolbars', 'patternfly.charts', 'patternfly.wizard', 'patternfly.validation', 'address_service']).config(
     function ($stateProvider, $urlRouterProvider) {
-        $urlRouterProvider.otherwise('/addresses');
+        $urlRouterProvider.otherwise('/dashboard');
+        $stateProvider.state('dashboard',
+                             { url: '/dashboard',
+                               templateUrl: 'dashboard.html'
+                             }
+                            );
         $stateProvider.state('addresses',
                              { url: '/addresses',
                                templateUrl: 'addresses.html'
@@ -772,6 +777,11 @@ angular.module('myapp', ['patternfly.navigation', 'ui.router', 'patternfly.views
     }).controller('NavCtrl', ['$scope',
     function ($scope) {
         $scope.navigationItems = [
+            {
+                title: "Dashboard",
+                iconClass: "fa fa-tachometer",
+                uiSref: "dashboard"
+            },
             {
                 title: "Addresses",
                 iconClass: "fa pficon-topology",


### PR DESCRIPTION
For address_service.js I added a "reason" to the callback so the dashboard charts would only update when the address data changed.

For index.html I added the dashboard page and a reference to a new enmasse.css

For script.js I added the Dashboard menu item and made it the default.

In the new file dashboard_ctrl.js I'm creating the charts manually because I believe there is a memory leak in the pf-c3-chart directive. [](https://github.com/c3js/c3/issues/926) 