### PR TITLE
Using patternfly directive for pie charts on dashboard page

### DIFF
--- a/www/dashboard.html
+++ b/www/dashboard.html
@@ -10,7 +10,7 @@
                     <div ng-repeat="pie in pies track by $index">
                         <div class="col-xs-12 col-sm-4 col-md-4">
                             <h3 class="card-pf-subtitle">{{pie.title}}</h3>
-                            <div id="pie-chart-{{pie.name}}" class="pie-chart-pf example-pie-chart-mini"></div>
+                            <div pf-c3-chart id="pie-chart-{{pie.name}}" config="get_chart_config(pie)" getChartCallback="pie.get_chart"></div>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
Now that the patternfly library has the fix for the chart memory leak, I've updated the pie charts on the dashboard page to use the patternfly pf-c3-chart directive.

This pull request should only be accepted if the "bowerify" pull request is accepted since that includes the patternfly fix. 