### PR TITLE
Force update of delivery rate

### DIFF
--- a/lib/router_stats.js
+++ b/lib/router_stats.js
@@ -57,7 +57,7 @@ function backlog (link_stats) {
 function routerName (link_stats, router) {
     return router && router.target ? router.target.split('/')[3] : undefined;
 }
-var defined_linkDetails = ['identity', 'operStatus', 'adminStatus', 'deliveryCount', 'capacity', backlog, routerName];
+var defined_linkDetails = ['identity', 'name', 'operStatus', 'adminStatus', 'deliveryCount', 'capacity', backlog, routerName];
 defined_linkDetails.push.apply(defined_linkDetails, defined_outcomes.map((d) => d+'Count'))
 
 function init_outcomes(outcomes) {


### PR DESCRIPTION
- better error checking on delivery rate calculation
- force an update of delivery rate if there have been no updates in last 7 seconds (assume rate is now 0)
- uses link.name and link.id to match stored link data since link.id might be reused if router is restarted
- don't show empty rows if link table is empty
- don't collapse address item if you click in the expanded area (so you can resize link table columns)